### PR TITLE
fix shulker dupe

### DIFF
--- a/src/main/java/com/grim3212/assorted/storage/common/crafting/LockedShulkerBoxColoring.java
+++ b/src/main/java/com/grim3212/assorted/storage/common/crafting/LockedShulkerBoxColoring.java
@@ -68,7 +68,7 @@ public class LockedShulkerBoxColoring extends CustomRecipe {
 			}
 		}
 
-		ItemStack copy = itemstack.copy();
+		ItemStack copy = itemstack.copyWithCount(1);
 		NBTHelper.putInt(copy, "Color", dyecolor.getId());
 		return copy;
 	}


### PR DESCRIPTION
when coloring multiple locked shulkers they get duped, this happens because the stacksize is copied, while the recipe only reduces one item from the count